### PR TITLE
fix: jade icon

### DIFF
--- a/preferences/icon_jade.tmPreferences
+++ b/preferences/icon_jade.tmPreferences
@@ -3,7 +3,7 @@
 <plist version="1.0">
   <dict>
     <key>scope</key>
-    <string>source.jade</string>
+    <string>source.jade, text.jade</string>
     <key>settings</key>
     <dict>
       <key>icon</key>


### PR DESCRIPTION
I noticed the Jade icon was inheriting the text icon instead of the Jade icon.

Before:
![screen shot 2016-04-19 at 12 02 03 pm](https://cloud.githubusercontent.com/assets/1154799/14646310/081bef64-0627-11e6-9ab2-e1bd2a4977b6.png)

After:
![screen shot 2016-04-19 at 12 02 20 pm](https://cloud.githubusercontent.com/assets/1154799/14646318/0ff3fc2c-0627-11e6-8efd-31b0cece9fb4.png)
